### PR TITLE
Fix streaming dying on screen-off: recover disconnected Oboe streams, survive transient audio focus loss

### DIFF
--- a/app/src/main/cpp/hark_audio_engine.cpp
+++ b/app/src/main/cpp/hark_audio_engine.cpp
@@ -1,6 +1,7 @@
 #include "hark_audio_engine.h"
 #include <android/log.h>
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <oboe/FifoBuffer.h>
 
@@ -13,10 +14,21 @@ HarkAudioEngine::~HarkAudioEngine() {
 }
 
 bool HarkAudioEngine::start(int32_t sampleRate, int32_t framesPerBurst) {
+    mShouldBeStreaming.store(false, std::memory_order_release);
+    joinRestartThread();
+
     std::lock_guard<std::mutex> lock(mStreamLock);
+    mSampleRate = sampleRate;
+    mFramesPerBurst = framesPerBurst;
+
+    bool success = openStreamsLocked();
+    mShouldBeStreaming.store(success, std::memory_order_release);
+    return success;
+}
+
+bool HarkAudioEngine::openStreamsLocked() {
     closeStreams();
 
-    mSampleRate = sampleRate;
     mResampleAccumulator = 0;
 
     // Reset processing states
@@ -25,7 +37,7 @@ bool HarkAudioEngine::start(int32_t sampleRate, int32_t framesPerBurst) {
     mPrevOutput = 0.0f;
     mIsBuffering = true;
 
-    uint32_t fifoCapacity = std::max(static_cast<uint32_t>(framesPerBurst) * 16, static_cast<uint32_t>(4096));
+    uint32_t fifoCapacity = std::max(static_cast<uint32_t>(mFramesPerBurst) * 16, static_cast<uint32_t>(4096));
     mFifoBuffer = std::make_unique<oboe::FifoBuffer>(sizeof(float), fifoCapacity);
 
     // Whisper.cpp usually expects 16kHz audio.
@@ -38,7 +50,7 @@ bool HarkAudioEngine::start(int32_t sampleRate, int32_t framesPerBurst) {
             ->setSharingMode(oboe::SharingMode::Exclusive)
             ->setFormat(oboe::AudioFormat::Float)
             ->setChannelCount(oboe::ChannelCount::Mono)
-            ->setSampleRate(sampleRate)
+            ->setSampleRate(mSampleRate)
             ->setInputPreset(oboe::InputPreset::VoiceCommunication)
             ->setDataCallback(this)
             ->setErrorCallback(this);
@@ -55,7 +67,7 @@ bool HarkAudioEngine::start(int32_t sampleRate, int32_t framesPerBurst) {
             ->setSharingMode(oboe::SharingMode::Exclusive)
             ->setFormat(oboe::AudioFormat::Float)
             ->setChannelCount(oboe::ChannelCount::Mono)
-            ->setSampleRate(sampleRate)
+            ->setSampleRate(mSampleRate)
             ->setDataCallback(this)
             ->setErrorCallback(this);
 
@@ -66,7 +78,7 @@ bool HarkAudioEngine::start(int32_t sampleRate, int32_t framesPerBurst) {
         return false;
     }
 
-    mOutStream->setBufferSizeInFrames(framesPerBurst * 2);
+    mOutStream->setBufferSizeInFrames(mFramesPerBurst * 2);
     mInStream->requestStart();
     mOutStream->requestStart();
 
@@ -74,8 +86,17 @@ bool HarkAudioEngine::start(int32_t sampleRate, int32_t framesPerBurst) {
 }
 
 void HarkAudioEngine::stop() {
+    mShouldBeStreaming.store(false, std::memory_order_release);
+    joinRestartThread();
     std::lock_guard<std::mutex> lock(mStreamLock);
     closeStreams();
+}
+
+void HarkAudioEngine::joinRestartThread() {
+    std::lock_guard<std::mutex> lock(mRestartThreadLock);
+    if (mRestartThread.joinable()) {
+        mRestartThread.join();
+    }
 }
 
 void HarkAudioEngine::closeStreams() {
@@ -83,9 +104,12 @@ void HarkAudioEngine::closeStreams() {
     if (mInStream) { mInStream->stop(); mInStream->close(); mInStream.reset(); }
     mTranscriptionFifo.reset();
     mFifoBuffer.reset();
+    mTranscriptionLevel.store(0.0f, std::memory_order_release);
 }
 
 int32_t HarkAudioEngine::readTranscriptionData(float *target, int32_t numFrames) {
+    // Called from a JVM thread; the restart thread may swap the FIFO under us
+    std::lock_guard<std::mutex> lock(mStreamLock);
     if (!mTranscriptionFifo) return 0;
     return mTranscriptionFifo->read(target, numFrames);
 }
@@ -275,4 +299,40 @@ float HarkAudioEngine::applySoftKneeLimiter(float input) {
 
 void HarkAudioEngine::onErrorAfterClose(oboe::AudioStream *audioStream, oboe::Result error) {
     __android_log_print(ANDROID_LOG_ERROR, TAG, "Stream error: %s", oboe::convertToText(error));
+
+    // Exclusive low-latency streams are torn down by the OS on route changes and
+    // screen-off. Oboe requires reopening the stream after ErrorDisconnected.
+    if (error != oboe::Result::ErrorDisconnected) return;
+    if (!mShouldBeStreaming.load(std::memory_order_acquire)) return;
+
+    bool expected = false;
+    if (!mRestartPending.compare_exchange_strong(expected, true)) return;
+
+    std::lock_guard<std::mutex> lock(mRestartThreadLock);
+    if (mRestartThread.joinable()) {
+        mRestartThread.join();
+    }
+    mRestartThread = std::thread([this] { restartStreams(); });
+}
+
+void HarkAudioEngine::restartStreams() {
+    for (int attempt = 0; attempt < 3; ++attempt) {
+        // Give the new audio route time to settle before reopening
+        std::this_thread::sleep_for(std::chrono::milliseconds(250 << attempt));
+        if (!mShouldBeStreaming.load(std::memory_order_acquire)) break;
+
+        std::lock_guard<std::mutex> lock(mStreamLock);
+        if (!mShouldBeStreaming.load(std::memory_order_acquire)) break;
+
+        if (openStreamsLocked()) {
+            __android_log_print(ANDROID_LOG_INFO, TAG,
+                    "Streams restarted after disconnect (attempt %d)", attempt + 1);
+            mRestartPending.store(false, std::memory_order_release);
+            return;
+        }
+        __android_log_print(ANDROID_LOG_WARN, TAG,
+                "Stream restart attempt %d failed", attempt + 1);
+    }
+    __android_log_print(ANDROID_LOG_ERROR, TAG, "Giving up on stream restart");
+    mRestartPending.store(false, std::memory_order_release);
 }

--- a/app/src/main/cpp/hark_audio_engine.h
+++ b/app/src/main/cpp/hark_audio_engine.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <cstdint>
 #include <vector>
+#include <thread>
 
 namespace oboe {
     class FifoBuffer;
@@ -62,6 +63,18 @@ private:
     bool mIsBuffering = true;
 
     std::mutex mStreamLock;
+
+    // Stream restart on disconnect (screen-off / route changes tear down
+    // exclusive low-latency streams; they must be reopened, see onErrorAfterClose)
+    std::atomic<bool> mShouldBeStreaming{false};
+    std::atomic<bool> mRestartPending{false};
+    std::thread mRestartThread;
+    std::mutex mRestartThreadLock;
+    int32_t mFramesPerBurst = 192;
+
+    bool openStreamsLocked();
+    void restartStreams();
+    void joinRestartThread();
 
     void closeStreams();
     float applySpeechEnhancement(float input);

--- a/app/src/main/java/com/thivyanstudios/hark/service/AudioStreamingService.kt
+++ b/app/src/main/java/com/thivyanstudios/hark/service/AudioStreamingService.kt
@@ -89,16 +89,25 @@ class AudioStreamingService : Service(), AudioStreamingController {
     private val _hearingAidConnected = MutableStateFlow(false)
     override val hearingAidConnected = _hearingAidConnected.asStateFlow()
 
+    private var pausedByFocusLoss = false
+
     private val audioFocusChangeListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
         when (focusChange) {
-            AudioManager.AUDIOFOCUS_LOSS,
-            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
-                HarkLog.i(TAG, "Audio focus lost, stopping streaming")
+            AudioManager.AUDIOFOCUS_LOSS -> {
+                HarkLog.i(TAG, "Audio focus lost permanently, stopping streaming")
                 stopStreaming()
+            }
+            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
+                HarkLog.i(TAG, "Audio focus lost transiently, pausing streaming")
+                pauseStreaming()
+            }
+            AudioManager.AUDIOFOCUS_GAIN -> {
+                HarkLog.i(TAG, "Audio focus regained, resuming streaming")
+                resumeStreamingAfterFocusGain()
             }
             AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> {
                 HarkLog.i(TAG, "Audio focus lost (duckable), continuing streaming")
-                // We could lower our output volume here if we were playing audio, 
+                // We could lower our output volume here if we were playing audio,
                 // but since we are mainly recording/transcribing, we continue.
             }
         }
@@ -492,11 +501,36 @@ class AudioStreamingService : Service(), AudioStreamingController {
         }
     }
 
+    // Transient focus loss (call, alarm, assistant): keep the session alive so we can
+    // resume when focus returns. The foreground notification and wake lock stay held.
+    private fun pauseStreaming() {
+        if (!_isStreaming.value || pausedByFocusLoss) return
+        pausedByFocusLoss = true
+        _audioLevel.value = 0f
+        serviceScope.launch {
+            withContext(ioDispatcher) {
+                audioEngine.stop()
+            }
+        }
+    }
+
+    private fun resumeStreamingAfterFocusGain() {
+        if (!pausedByFocusLoss) return
+        pausedByFocusLoss = false
+        if (!_isStreaming.value) return
+        serviceScope.launch {
+            withContext(ioDispatcher) {
+                audioEngine.start()
+            }
+        }
+    }
+
     override fun stopStreaming() {
         if (!_isStreaming.value) return
-        
+
         HarkLog.i(TAG, "Stopping streaming")
         _isStreaming.value = false
+        pausedByFocusLoss = false
         clearAudioRouting()
         abandonAudioFocus()
         


### PR DESCRIPTION
Hi @thivyan-studios — first off, thanks for building HARK. My father uses it daily with his hearing aids on a Samsung S25, which is how we ran into this bug: streaming would silently die when he put the phone down and the screen turned off. I traced it through the codebase and this PR fixes the two root causes we found. Details below; happy to adjust anything to fit how you'd like the code structured.

## Problem

Streaming sessions ended silently on screen-off and never recovered after interruptions like calls or alarms. Two independent failure modes:

1. **Oboe stream disconnects were never recovered.** Both streams use `SharingMode::Exclusive` + `PerformanceMode::LowLatency`; the OS tears these down on screen-off and audio route changes. `HarkAudioEngine::onErrorAfterClose` only logged the error, so `AudioStreamingService` kept `isStreaming = true` (notification up, wake lock held) while audio was dead.
2. **Transient audio focus loss stopped streaming permanently.** `AUDIOFOCUS_LOSS_TRANSIENT` (incoming call, alarm, assistant) called `stopStreaming()`, and there was no `AUDIOFOCUS_GAIN` handler to resume. For a hearing-aid user this is exactly the moment they won't notice it stopped.

## Fix

**Native (`hark_audio_engine.cpp/h`):**
- On `ErrorDisconnected`, reopen both streams on a dedicated restart thread (up to 3 attempts with 250/500/1000 ms backoff) — the pattern Oboe documents for exclusive streams.
- Stream-opening logic extracted into `openStreamsLocked()`; `start()`/`stop()` set a `mShouldBeStreaming` flag and join the restart thread *before* taking the stream lock, so a concurrent stop/start from Kotlin always wins and no deadlock is possible.
- `readTranscriptionData` now takes the stream lock (the restart thread swaps the FIFO under a concurrent JVM reader).
- Audio level is zeroed when streams close so the UI doesn't show a frozen stale level.

**Kotlin (`AudioStreamingService.kt`):**
- `AUDIOFOCUS_LOSS_TRANSIENT` → pause: stop the engine but keep the foreground notification, wake lock, and focus request alive.
- `AUDIOFOCUS_GAIN` → resume the engine (Whisper context stays initialized, so resume is fast).
- Permanent `AUDIOFOCUS_LOSS` still stops the session; `stopStreaming()` clears the paused flag.

## Verification

- `./gradlew assembleDebug` — BUILD SUCCESSFUL (NDK 28.2, full native compile).
- On-device check for the disconnect path: start streaming, turn the screen off, watch `adb logcat -s HarkAudioEngine` for `Stream error: ErrorDisconnected` followed by `Streams restarted after disconnect`.
- On-device check for the focus path: while streaming, trigger a timer/alarm, dismiss it, confirm audio resumes without touching the app.

## Notes

- `testDebugUnitTest` currently doesn't compile on `main`: `MainViewModelTest`/`SettingsViewModelTest` still use constructor signatures from before the "Modular AI, v3.1.1" refactor (d8de718). Pre-existing, so I left it out of this PR's scope, but happy to fix those in a follow-up.
- Related follow-up worth considering: a one-time in-app prompt for the battery-optimization exemption. Samsung's "put apps to sleep" can still kill the process outright; on my father's S25 we worked around it manually (Settings → Apps → HARK → Battery → Unrestricted), but since the app's whole purpose is running with the screen off, guiding users there would save them this debugging session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)